### PR TITLE
Add GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+#  schedule:
+#    - cron: '42 5 * * *'
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest] #, macos-latest, windows-latest]
+        python-version: ["3.11"]
+
+    runs-on: ${{matrix.runner}}
+    name: OS ${{matrix.runner}} Python ${{matrix.python-version}}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        pip install -r requirements.txt -r requirements-dev.txt
+        pip install kongodb
+        pip install -e .
+
+    - name: Check Python version
+      run: python -V
+
+    - name: Test with pytest
+      run: pytest -svv
+


### PR DESCRIPTION
I am using [Pydigger](https://pydigger.com/) to monitor recent uploads to PyPI that don't have any Continous Integration (CI) system configured.
A CI system can greatly improve the development experience by providing quick feedback to the developers and contributors, even for a toy or experimental project.
As my contribution to open source (see [why](https://osdc.code-maven.com/why))I try to contribute a simple CI configuration to these projects to get started. 
I'd be glad to answer any question you might have about this PR.


This CI currently fails due to #2 and I have only enable a single operating system and a single version of Python.